### PR TITLE
Add address field for envelope type "DIN lang mit Fenster"

### DIFF
--- a/Beitrittserklärung/anschreiben_beitritt.tex
+++ b/Beitrittserklärung/anschreiben_beitritt.tex
@@ -1,0 +1,30 @@
+\documentclass[de-RSE_Brief,a4paper]{scrlttr2}
+\usepackage[ngerman,KeepShorthandsActive]{babel}
+
+
+\usepackage{lmodern}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+\setkomavar*{enclseparator}{Anlage}
+\setkomavar{subject}{Beitrittserklärung der de-RSE e.V. - Gesellschaft für Forschungssoftware}
+\setkomavar{date}{\today}
+\setkomavar{place}{Berlin}
+
+\begin{letter}{
+    Maxine Musterfrau\\
+    Musterstraße 0815\\
+    D-01234 Oberkleindorf
+}
+\opening{Liebe Maxine,}
+Vielen Dank für dein Interesse an der \emph{de-RSE e.V. - Gesellschaft für Forschungssoftware}.
+Anbei findest du unsere Beitrittserklärung für eine Vereinsmitgliedschaft. Bitte sende das
+ausgefüllte und unterschriebene Formular an die auf der Rückseite der Erklärung angegebene Adresse.
+Wir freuen uns schon auf deine Beteiligung!
+
+\closing{Mit besten Grüßen}
+\end{letter}
+
+\end{document}
+

--- a/Beitrittserklärung/de-RSE-logo-text-colour.pdf
+++ b/Beitrittserklärung/de-RSE-logo-text-colour.pdf
@@ -1,0 +1,1 @@
+../Vorlagen/de-RSE-logo-text-colour.pdf

--- a/Beitrittserklärung/de-RSE_Brief.lco
+++ b/Beitrittserklärung/de-RSE_Brief.lco
@@ -1,0 +1,1 @@
+../Vorlagen/de-RSE_Brief.lco

--- a/Beitrittserklärung/de-RSE_Kopf.lco
+++ b/Beitrittserklärung/de-RSE_Kopf.lco
@@ -1,0 +1,1 @@
+../Vorlagen/de-RSE_Kopf.lco

--- a/Beitrittserklärung/erklärung.tex
+++ b/Beitrittserklärung/erklärung.tex
@@ -3,6 +3,7 @@
 \usepackage{mathpazo}
 \usepackage[hidelinks]{hyperref}
 \usepackage{setspace}
+\usepackage{rotating}
 
 \pagestyle{empty}
 
@@ -70,5 +71,20 @@ Datum:        & \TextField[height=0.01cm, width=0.2\textwidth]{} & Unterschrift:
 \end{tabular}
 
 \end{Form}
+\vspace*{1cm}
+Bitte das ausgefüllte Formular an die untenstehende Adresse schicken.
+
+\vfill
+\flushright
+---\\
+\vspace*{2.7cm}
+\begin{turn}{180}
+  \begin{minipage}{15cm}
+    de-RSE e.V.\\
+    Kleineweg 79\\
+    12101 Berlin
+  \end{minipage}
+\end{turn}
+\vspace*{1cm}
 \end{letter}
 \end{document}


### PR DESCRIPTION
An address field (including folding marker) was added at the bottom of the second page to easily send the printed from in a standard "DIN lang mit Fenster" envelope.